### PR TITLE
Disable quicklinks with outdated sign-up links

### DIFF
--- a/src/components/pages/content/ContentRender.js
+++ b/src/components/pages/content/ContentRender.js
@@ -4,7 +4,7 @@ import ReactMarkdown from "react-markdown";
 import Grid from '@material-ui/core/Grid';
 import Aux from "../../../hoc/Aux";
 import FbPagePlugin from "./FbPagePlugin";
-import QuickLinks from "./QuickLinks";
+// import QuickLinks from "./QuickLinks";
 
 // const useStyles = makeStyles(theme => ({
 //     container: {
@@ -28,7 +28,7 @@ const ContentRender = props => {
     // const classes = useStyles();
     const pageContent = <ReactMarkdown source={props.content}/>;
     const fbPagePlugin = <FbPagePlugin/>;
-    const quickLinks = <QuickLinks/>;
+    // const quickLinks = <QuickLinks/>;
     return (
         isBigScreen ?
             <Grid container spacing={4}>
@@ -36,14 +36,14 @@ const ContentRender = props => {
                     {pageContent}
                 </Grid>
                 <Grid item xs={4}>
-                    {quickLinks}
+                    { /*quickLinks*/ }
                     {fbPagePlugin}
                 </Grid>
             </Grid>
             :
             <Aux>
                 {pageContent}
-                {quickLinks}
+                { /*quickLinks*/ }
                 {fbPagePlugin}
             </Aux>
     );


### PR DESCRIPTION
The sign-up links are for the past semester and the element looks a bit "empty" with just the contact address (it's also in the footer). And once we have new sign-ups, we can just reactivate.

Also obviously feel free to disregard this PR and do such a change yourself if whatever I did isn't "ideal" :)